### PR TITLE
Implemented /remove command

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -377,6 +377,21 @@ def warn_user(user, msid, delete=False):
 	return rp.Reply(rp.types.SUCCESS)
 
 @requireUser
+@requireRank(RANKS.mod)
+def remove(user, msid, reason):
+    cm = ch.getMessage(msid)
+    if cm is None or cm.user_id is None:
+        return rp.Reply(rp.types.ERR_NOT_IN_CACHE)
+
+    user2 = db.getUser(id=cm.user_id)
+    _push_system_message(
+        rp.Reply(rp.types.MESSAGE_REMOVED, reason=reason),
+        who=user2, reply_to=msid)
+    Sender.delete(msid)
+    logging.info("%s had a message removed by %s for: %s", user2, user, reason)
+    return rp.Reply(rp.types.SUCCESS)
+
+@requireUser
 @requireRank(RANKS.admin)
 def uncooldown_user(user, oid2=None, username2=None):
 	if oid2 is not None:

--- a/src/replies.py
+++ b/src/replies.py
@@ -37,6 +37,7 @@ types = NumericEnum([
 	"USER_IN_CHAT",
 	"USER_NOT_IN_CHAT",
 	"GIVEN_COOLDOWN",
+	"MESSAGE_REMOVED",
 	"PROMOTED_MOD",
 	"PROMOTED_ADMIN",
 	"KARMA_THANK_YOU",
@@ -100,6 +101,8 @@ format_strs = {
 	types.GIVEN_COOLDOWN: lambda deleted, **_:
 		em( "You've been handed a cooldown of {duration!d} for this message"+
 			(deleted and " (message also deleted)" or "") ),
+	types.MESSAGE_REMOVED: lambda reason, **_:
+		em("Your message has been removed" + (reason and " for {reason!x}. " or ". ") + "No cooldown has been given, but refrain from posting the message again."),
 	types.PROMOTED_MOD: em("You've been promoted to moderator, run /modhelp for a list of commands."),
 	types.PROMOTED_ADMIN: em("You've been promoted to admin, run /adminhelp for a list of commands."),
 	types.KARMA_THANK_YOU: em("You just gave this user some sweet karma, awesome!"),
@@ -157,7 +160,8 @@ format_strs = {
 		"<i>Or reply to a message and use</i>:\n"+
 		"  /info - get info about the user that sent this message\n"+
 		"  /warn - warn the user that sent this message (cooldown)\n"+
-		"  /delete - delete a message and warn the user",
+		"  /delete - delete a message and warn the user\n"+
+		"  /remove [reason] - delete a message without a cooldown",
 	types.HELP_ADMIN:
 		"<i>Admins can use the following commands</i>:\n"+
 		"  /adminhelp - show this text\n"+

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -41,7 +41,7 @@ def init(config, _db, _ch):
 	cmds = [
 		"start", "stop", "users", "info", "motd", "toggledebug", "togglekarma",
 		"version", "source", "modhelp", "adminhelp", "modsay", "adminsay", "mod",
-		"admin", "warn", "delete", "uncooldown", "blacklist", "s", "sign",
+		"admin", "warn", "delete", "remove", "uncooldown", "blacklist", "s", "sign",
 		"tripcode", "settripcode", "t", "tsign"
 	]
 	for c in cmds: # maps /<c> to the function cmd_<c>
@@ -467,6 +467,19 @@ def cmd_uncooldown(ev, arg):
 		username = arg
 
 	send_answer(ev, core.uncooldown_user(c_user, oid, username), True)
+
+@takesArgument(optional=True)
+def cmd_remove(ev, arg):
+    c_user = UserContainer(ev.from_user)
+
+    if ev.reply_to_message is None:
+        return send_answer(ev, rp.Reply(rp.types.ERR_NO_REPLY), True)
+
+    reply_msid = ch.lookupMapping(ev.from_user.id, data=ev.reply_to_message.message_id)
+    if reply_msid is None:
+        return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
+
+    send_answer(ev, core.remove(c_user, reply_msid, arg), True)
 
 @takesArgument(optional=True)
 def cmd_blacklist(ev, arg):


### PR DESCRIPTION
Copied from the /blacklist command and made a /remove command. Deletes a post without handing a cooldown. Also allows mods and admins to give an reason for the removal of the post.